### PR TITLE
Update main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,9 +2,9 @@
 - name: Detect and Download Installer
   include: 01-download-installer-detect.yml
   when: mq_detect_download_installer and mq_local_installer is undefined
-- name: Download Installer
-  include: 01-download-installer.yml
-  when: mq_download_installer and mq_local_installer is undefined
+#- name: Download Installer
+#  include: 01-download-installer.yml
+#  when: mq_download_installer and mq_local_installer is undefined
 - name: Install from provided file
   unarchive:
    src:  "{{ mq_local_installer }}"


### PR DESCRIPTION
I think the 01-download-installer-detect.yml is getting the latest version.  However the 01-download-installer.yml is then repeating the download and unar tasks for an old version that it's getting from the vars.  Therefore it is un-needed