### PR TITLE
Update 01-download-installer-detect.yml

### DIFF
--- a/tasks/01-download-installer-detect.yml
+++ b/tasks/01-download-installer-detect.yml
@@ -10,11 +10,11 @@
   register: var_platform
 - name: Auto detect installer for {{ ansible_facts.os_family }} Downloading. Will take some minutes
   get_url:
-    url: "{{ mq_ibm_url }}{{ var_platform.stdout_lines[0] }}"
-    dest: "{{ mq_install_dir }}/{{ var_platform.stdout_lines[0] }}"
-- name: untar install archive "{{ mq_install_dir }}{{ var_platform.stdout_lines[0] }}"
+    url: "{{ mq_ibm_url }}{{ var_platform.stdout_lines[-1] }}"
+    dest: "{{ mq_install_dir }}/{{ var_platform.stdout_lines[-1] }}"
+- name: untar install archive "{{ mq_install_dir }}{{ var_platform.stdout_lines[-1] }}"
   unarchive:
-   src:  "{{ mq_install_dir }}{{ var_platform.stdout_lines[0] }}"
+   src:  "{{ mq_install_dir }}{{ var_platform.stdout_lines[-1] }}"
    dest: "{{ mq_install_dir }}"
    copy: no
    creates: "{{ mq_install_dir }}{{ mq_uncompress_dir }}"


### PR DESCRIPTION
I've found on some OS that the read.py script can generate a bash error relating to the locale setting which I couldnt resolve.  So using -1 (i.e. the last line) in the stdout_lines resolves that issue